### PR TITLE
Improve windows and androidx compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ lib/
 app.apk
 keystore.jks
 ids.txt
-NUL

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+build/
+lib/
+app.apk
+keystore.jks
+ids.txt
+NUL

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,23 +1,23 @@
-<?xml version='1.0'?>
+<?xml version="1.0"?>
 <manifest
-	xmlns:android='http://schemas.android.com/apk/res/android'
-	xmlns:app='http://schemas.android.com/apk/res-auto'
-	xmlns:tools='http://schemas.android.com/tools'
-	package='com.example.test'
-	android:versionCode='0'
-	android:versionName='0'>
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
+	package="com.example.test"
+	android:versionCode="0"
+	android:versionName="0">
 
 	<uses-sdk
 		android:minSdkVersion="15"
-		android:targetSdkVersion="30"
+		android:targetSdkVersion="28"
 	/>
 
-    <application android:label='@string/app_name' android:theme='@style/app_style'>
-        <activity android:name='.MainActivity'>
-             <intent-filter>
-                <category android:name='android.intent.category.LAUNCHER'/>
-                <action android:name='android.intent.action.MAIN'/>
-             </intent-filter>
-        </activity>
-    </application>
+	<application android:label="@string/app_name" android:theme="@style/app_style">
+		<activity android:name=".MainActivity">
+			<intent-filter>
+				<category android:name="android.intent.category.LAUNCHER"/>
+				<action android:name="android.intent.action.MAIN"/>
+			</intent-filter>
+		</activity>
+	</application>
 </manifest>

--- a/export-libs.pl
+++ b/export-libs.pl
@@ -172,6 +172,7 @@ foreach my $pkg (<$LIB_RES_DIR/res_*>) {
 
 				foreach my $fname (<$type_dir/*>) {
 					open(my $fh, '<', $fname);
+					binmode($fh);
 					read($fh, my $content, -s $fh);
 					close($fh);
 
@@ -183,6 +184,7 @@ foreach my $pkg (<$LIB_RES_DIR/res_*>) {
 					my $out_xml = "$out_dir/$xml_name";
 
 					open($fh, '>', $out_xml);
+					binmode($fh);
 					print $fh $content;
 					close($fh);
 				}

--- a/export-libs.pl
+++ b/export-libs.pl
@@ -198,6 +198,7 @@ foreach my $pkg (<$LIB_RES_DIR/res_*>) {
 
 				foreach my $fname (<$type_dir/*>) {
 					open(my $fh, '<', $fname);
+					# files must be read in binary mode, otherwise windows will interpret any LF-newline ("\n") byte as two CRLF-newline bytes ("\r\n").
 					binmode($fh);
 					read($fh, my $content, -s $fh);
 					close($fh);
@@ -210,6 +211,7 @@ foreach my $pkg (<$LIB_RES_DIR/res_*>) {
 					my $out_xml = "$out_dir/$xml_name";
 
 					open($fh, '>', $out_xml);
+					# files must be read in binary mode, otherwise windows will interpret any LF-newline ("\n") byte as two CRLF-newline bytes ("\r\n").
 					binmode($fh);
 					print $fh $content;
 					close($fh);

--- a/export-libs.pl
+++ b/export-libs.pl
@@ -11,8 +11,9 @@ my $ANDROID_VERSION;
 my $LIB_RES_DIR;
 my $LIB_CLASS_DIR;
 my $CMD_DELETE;
-my $CMD_COPY;
+my $CMD_COPY_RECURSIVE;
 my $CMD_7Z;
+my $DEV_NULL;
 
 # get variables from includes.sh
 {
@@ -106,13 +107,13 @@ if (!-d "lib") {
 
 if (-d "$LIB_RES_DIR") {
 	print("Clearing old library resources...\n");
-	exit if (system("$CMD_DELETE $LIB_RES_DIR") != 0);
+	exit if (system("$CMD_DELETE \"$LIB_RES_DIR\"") != 0);
 	mkdir("$LIB_RES_DIR");
 }
 
 if (-d "$LIB_CLASS_DIR") {
 	print("Clearing old library classes...\n");
-	exit if (system("$CMD_DELETE $LIB_CLASS_DIR") != 0);
+	exit if (system("$CMD_DELETE \"$LIB_CLASS_DIR\"") != 0);
 	mkdir("$LIB_CLASS_DIR");
 }
 
@@ -120,14 +121,14 @@ print("Extracting library resources and classes...\n");
 
 # A JAR is basically just a ZIP file packed with classes in a certain folder structure, so we just extract everything.
 foreach (<lib/*.jar>) {
-	system("$CMD_7Z x -y '$_' -o$LIB_CLASS_DIR > /dev/null");
+	system("$CMD_7Z x -y \"$_\" -o\"$LIB_CLASS_DIR\" > $DEV_NULL");
 }
 
 # AAR is the Android library format. It's essentially a ZIP containing a JAR and some resources.
 foreach (<lib/*.aar>) {
-	system("$CMD_7Z x -y '$_' -o$LIB_RES_DIR res classes.jar R.txt AndroidManifest.xml > /dev/null");
+	system("$CMD_7Z x -y \"$_\" -o\"$LIB_RES_DIR\" res classes.jar R.txt AndroidManifest.xml > $DEV_NULL");
 
-	system("$CMD_7Z x -y '$LIB_RES_DIR/classes.jar' -o$LIB_CLASS_DIR > /dev/null");
+	system("$CMD_7Z x -y \"$LIB_RES_DIR/classes.jar\" -o\"$LIB_CLASS_DIR\" > $DEV_NULL");
 	unlink("$LIB_RES_DIR/classes.jar");
 
 	my $name = substr($_, 4, -4);
@@ -187,7 +188,7 @@ foreach my $pkg (<$LIB_RES_DIR/res_*>) {
 				}
 			}
 			else {
-				system("$CMD_COPY -r '$type_dir' $LIB_RES_DIR/res");
+				system("$CMD_COPY_RECURSIVE \"$type_dir\" \"$LIB_RES_DIR/res\"");
 			}
 			next;
 		}

--- a/export-libs.pl
+++ b/export-libs.pl
@@ -2,6 +2,9 @@
 
 use strict;
 use warnings;
+use File::Spec;
+use File::Path qw(rmtree);
+use File::Copy qw(copy);
 
 my @DELETE_LIST = (
 	qr/app:layout_behavior="[^"^`]*"/
@@ -10,10 +13,8 @@ my @DELETE_LIST = (
 my $ANDROID_VERSION;
 my $LIB_RES_DIR;
 my $LIB_CLASS_DIR;
-my $CMD_DELETE;
-my $CMD_COPY_RECURSIVE;
 my $CMD_7Z;
-my $DEV_NULL;
+my $DEVNULL = File::Spec->devnull; # this is named differently from "$DEV_NULL" defined in "includes.sh", because we don't want this to get overwritten by it.
 
 # get variables from includes.sh
 {
@@ -31,6 +32,31 @@ my $DEV_NULL;
 	}
 
 	close($FILE);
+}
+
+# Recurive directory copying function
+sub dircopy {
+    my ($source_dir, $destination_dir) = @_;
+
+    opendir(my $dh, $source_dir) or die "Cannot open source directory '$source_dir': $!";
+	if (!-d $destination_dir) { make_path($destination_dir); }
+
+    while (my $entry = readdir($dh)) {
+        next if $entry eq '.' or $entry eq '..';
+
+        my $source_path = "$source_dir/$entry";
+        my $target_path = "$destination_dir/$entry";
+
+        if (-d $source_path) {
+            # Recurse into subdirectories
+            dircopy($source_path, $target_path);
+        } else {
+            # Copy regular files using File::Copy
+            copy($source_path, $target_path) or die "Copy failed: $!";
+        }
+    }
+
+    closedir($dh);
 }
 
 # I make the assumption that all tags that don't directly belong to the <resources> tag can be ignored when looking for merge conflicts.
@@ -107,13 +133,13 @@ if (!-d "lib") {
 
 if (-d "$LIB_RES_DIR") {
 	print("Clearing old library resources...\n");
-	exit if (system("$CMD_DELETE \"$LIB_RES_DIR\"") != 0);
+	rmtree($LIB_RES_DIR) or die "Cannot remove directory \"$LIB_RES_DIR\": $!";
 	mkdir("$LIB_RES_DIR");
 }
 
 if (-d "$LIB_CLASS_DIR") {
 	print("Clearing old library classes...\n");
-	exit if (system("$CMD_DELETE \"$LIB_CLASS_DIR\"") != 0);
+	rmtree($LIB_CLASS_DIR) or die "Cannot remove directory \"$LIB_CLASS_DIR\": $!";
 	mkdir("$LIB_CLASS_DIR");
 }
 
@@ -121,14 +147,14 @@ print("Extracting library resources and classes...\n");
 
 # A JAR is basically just a ZIP file packed with classes in a certain folder structure, so we just extract everything.
 foreach (<lib/*.jar>) {
-	system("$CMD_7Z x -y \"$_\" -o\"$LIB_CLASS_DIR\" > $DEV_NULL");
+	system("$CMD_7Z x -y \"$_\" -o\"$LIB_CLASS_DIR\" > $DEVNULL");
 }
 
 # AAR is the Android library format. It's essentially a ZIP containing a JAR and some resources.
 foreach (<lib/*.aar>) {
-	system("$CMD_7Z x -y \"$_\" -o\"$LIB_RES_DIR\" res classes.jar R.txt AndroidManifest.xml > $DEV_NULL");
+	system("$CMD_7Z x -y \"$_\" -o\"$LIB_RES_DIR\" res classes.jar R.txt AndroidManifest.xml > $DEVNULL");
 
-	system("$CMD_7Z x -y \"$LIB_RES_DIR/classes.jar\" -o\"$LIB_CLASS_DIR\" > $DEV_NULL");
+	system("$CMD_7Z x -y \"$LIB_RES_DIR/classes.jar\" -o\"$LIB_CLASS_DIR\" > $DEVNULL");
 	unlink("$LIB_RES_DIR/classes.jar");
 
 	my $name = substr($_, 4, -4);
@@ -190,7 +216,7 @@ foreach my $pkg (<$LIB_RES_DIR/res_*>) {
 				}
 			}
 			else {
-				system("$CMD_COPY_RECURSIVE \"$type_dir\" \"$LIB_RES_DIR/res\"");
+				dircopy($type_dir, "$LIB_RES_DIR/res") or die "Cannot copy: $!";
 			}
 			next;
 		}

--- a/get-packages.sh
+++ b/get-packages.sh
@@ -70,7 +70,7 @@ if [ $# -lt 1 ]; then
 	exit
 fi
 
-[ ! -d "$PKG_OUTPUT" ] && mkdir -p "$PKG_OUTPUT"
+[ ! -d "$PKG_OUTPUT" ] && $CMD_MKDIR -p "$PKG_OUTPUT"
 
 if [ $# -eq 2 ]; then
 	get_naive $1 $2

--- a/includes.sh
+++ b/includes.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # Roughly arranged in descending order of how likely you'll need to change each value
 
-HOST_OS="linux-x86_64"
-API_LEVEL="30"
-ANDROID_VERSION="11"
-NDK_VERSION="r23-beta4"
+HOST_OS="windows-x86_64" # use "windows-x86_64" for windows, and "linux-x86_64" for linux
+API_LEVEL="28"
+ANDROID_VERSION="10"
+NDK_VERSION="23.0.7599858"
 TARGET_ARCHES=( "arm64-v8a" )
-SDK_DIR="../Sdk"
+SDK_DIR="C:/Android/sdk"
 KOTLIN_LIB_DIR="/usr/share/kotlin/lib"
 
 REPO="https://dl.google.com/dl/android/maven2"
@@ -14,10 +14,10 @@ REPO="https://dl.google.com/dl/android/maven2"
 KEYSTORE="keystore.jks"
 KS_PASS="123456"
 
-TOOLS_DIR="$SDK_DIR/android-$ANDROID_VERSION"
-PLATFORM_DIR="$SDK_DIR/android-$ANDROID_VERSION"
+TOOLS_DIR="$SDK_DIR/build-tools/28.0.3"
+PLATFORM_DIR="$SDK_DIR/platforms/android-28"
 
-NDK_DIR="$SDK_DIR/android-ndk-$NDK_VERSION"
+NDK_DIR="$SDK_DIR/ndk/${NDK_VERSION}"
 NDK_BIN_DIR="$NDK_DIR/toolchains/llvm/prebuilt/$HOST_OS/bin"
 NDK_INCLUDE_DIR="$NDK_DIR/toolchains/llvm/prebuilt/$HOST_OS/usr/sysroot/include"
 NDK_LIB_DIR="$NDK_DIR/toolchains/llvm/prebuilt/$HOST_OS/usr/sysroot/lib"
@@ -30,10 +30,12 @@ PKG_OUTPUT="lib"
 JAR_TOOLS="java -Xmx1024M -Xss1m -jar $TOOLS_DIR/lib"
 
 CMD_7Z="7z"
-CMD_MKDIR="mkdir"
-CMD_RENAME="mv"
-CMD_DELETE="rm -rf"
-CMD_FIND="/usr/bin/find"
+CMD_MKDIR="mkdir" # use "mkdir" for windows, and "mkdir" for linux
+CMD_RENAME="ren" # use "ren" for windows, and "mv" for linux
+CMD_COPY_RECURSIVE="xcopy" # use "xcopy" for windows, and "cp -r" for linux
+CMD_DELETE="rmdir /s /q" # use "rmdir /s /q" for windows, and "rm -rf" for linux
+CMD_FIND_SRC_JAVA="ls -r src/**.java" # use "ls -r src/**.java" for windows, and "usr/bin/find src -name \"*.java\"" for linux
+CMD_FIND_SRC_KOTLIN="ls -r src/**.kt" # use "ls -r src/**.kt" for windows, and "usr/bin/find src -name \"*.kt\"" for linux
 CMD_CURL="curl"
 CMD_SED="sed"
 CMD_JAR="jar"
@@ -43,3 +45,5 @@ CMD_KOTLINC="kotlinc"
 
 CMD_ADB="$SDK_DIR/platform-tools/adb"
 CMD_D8="$CMD_JAVA -Xmx1024M -Xss1m -cp $TOOLS_DIR/lib/d8.jar com.android.tools.r8.D8"
+
+DEV_NULL="NUL" # use "NUL" for windows, and "/dev/null" for linux

--- a/includes.sh
+++ b/includes.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Roughly arranged in descending order of how likely you'll need to change each value
+# Note that windows users need to install a bash terminal for the scripts to run. Git-Bash is a good option, as it comes bundled with git.
 
 HOST_OS="windows-x86_64" # use "windows-x86_64" for windows, and "linux-x86_64" for linux
 API_LEVEL="28"

--- a/includes.sh
+++ b/includes.sh
@@ -14,8 +14,8 @@ REPO="https://dl.google.com/dl/android/maven2"
 KEYSTORE="keystore.jks"
 KS_PASS="123456"
 
-TOOLS_DIR="$SDK_DIR/build-tools/28.0.3"
-PLATFORM_DIR="$SDK_DIR/platforms/android-28"
+TOOLS_DIR="$SDK_DIR/build-tools/${API_LEVEL}" # verify that the directory with this name exists, because it may be named a little different.
+PLATFORM_DIR="$SDK_DIR/platforms/android-${API_LEVEL}"
 
 NDK_DIR="$SDK_DIR/ndk/${NDK_VERSION}"
 NDK_BIN_DIR="$NDK_DIR/toolchains/llvm/prebuilt/$HOST_OS/bin"
@@ -30,12 +30,10 @@ PKG_OUTPUT="lib"
 JAR_TOOLS="java -Xmx1024M -Xss1m -jar $TOOLS_DIR/lib"
 
 CMD_7Z="7z"
-CMD_MKDIR="mkdir" # use "mkdir" for windows, and "mkdir" for linux
-CMD_RENAME="ren" # use "ren" for windows, and "mv" for linux
-CMD_COPY_RECURSIVE="xcopy" # use "xcopy" for windows, and "cp -r" for linux
-CMD_DELETE="rmdir /s /q" # use "rmdir /s /q" for windows, and "rm -rf" for linux
-CMD_FIND_SRC_JAVA="ls -r src/**.java" # use "ls -r src/**.java" for windows, and "usr/bin/find src -name \"*.java\"" for linux
-CMD_FIND_SRC_KOTLIN="ls -r src/**.kt" # use "ls -r src/**.kt" for windows, and "usr/bin/find src -name \"*.kt\"" for linux
+CMD_MKDIR="mkdir"
+CMD_RENAME="mv"
+CMD_DELETE="rm -rf"
+CMD_FIND="find"
 CMD_CURL="curl"
 CMD_SED="sed"
 CMD_JAR="jar"
@@ -46,4 +44,4 @@ CMD_KOTLINC="kotlinc"
 CMD_ADB="$SDK_DIR/platform-tools/adb"
 CMD_D8="$CMD_JAVA -Xmx1024M -Xss1m -cp $TOOLS_DIR/lib/d8.jar com.android.tools.r8.D8"
 
-DEV_NULL="NUL" # use "NUL" for windows, and "/dev/null" for linux
+DEV_NULL="/dev/null" # device null location. "/dev/null" works in git-bash on windows. but some alternate bash implementation on windows may require you to use "NUL" instead.

--- a/jni-compile.sh
+++ b/jni-compile.sh
@@ -5,8 +5,8 @@ source includes.sh
 
 OUTPUT="libjni-example.so"
 
-#CPP_FILES=`find src -name "*.cpp"`
-C_FILES=`find src -name "*.c"`
+#CPP_FILES=`$CMD_FIND src -name "*.cpp"`
+C_FILES=`$CMD_FIND src -name "*.c"`
 
 INCLUDE_DIRS="-I$NDK_INCLUDE_DIR"
 LIB_DIRS="-L$NDK_LIB_DIR/aarch64-linux-android/$API_LEVEL"

--- a/link.pl
+++ b/link.pl
@@ -388,7 +388,8 @@ open(my $fh, '<', "ids.txt");
 chomp(my @ids = <$fh>);
 close($fh);
 
-system("$CMD_DELETE ids.txt");
+# system("$CMD_DELETE \"ids.txt\"");
+unlink("ids.txt");
 
 print("Generating project R.txt...\n");
 

--- a/link.pl
+++ b/link.pl
@@ -412,7 +412,7 @@ if (-d $LIB_RES_DIR && -d $LIB_CLASS_DIR) {
 	print("Compiling resource maps...\n");
 	mkdir("$LIB_RES_DIR/R") if (!-d "$LIB_RES_DIR/R");
 
-	system("$CMD_JAVAC -source 8 -target 8 -bootclasspath $PLATFORM_DIR/android.jar -d \"$LIB_RES_DIR/R\" \@rjava_list.txt");
+	system("$CMD_JAVAC --release 8 -classpath \"$PLATFORM_DIR/android.jar\" -d \"$LIB_RES_DIR/R\" \@rjava_list.txt");
 	exit if ($? != 0);
 	unlink("rjava_list.txt");
 
@@ -453,7 +453,7 @@ print("Compiling project R.java...\n");
 
 mkdir("build/R") if (!-d "build/R");
 
-system("$CMD_JAVAC -source 8 -target 8 -bootclasspath $PLATFORM_DIR/android.jar build/R.java -d build/R");
+system("$CMD_JAVAC --release 8 -classpath \"$PLATFORM_DIR/android.jar\" build/R.java -d build/R");
 exit if ($? != 0);
 
 system("$CMD_JAR --create --file build/R.jar -C build/R .");

--- a/link.pl
+++ b/link.pl
@@ -209,7 +209,7 @@ sub update_res_ids {
 	}
 	push(@table, $size);
 
-	# Make a copy of each R.txt and embed it into one homogenous string. This is likely faster than scanning each file individually.
+	# Make a copy of each R.txt and embed it into one homogeneous string. This is likely faster than scanning each file individually.
 	my $blob = pack($fmt, @files);
 
 	# Make an index of replacements to happen later. This means there (shouldn't) be any search-replace ordering issues.
@@ -366,7 +366,7 @@ my $aapt2_res = "build/res.zip";
 if (-d "lib") {
 	print("Compiling library resources...\n");
 
-	system("$TOOLS_DIR/aapt2 compile -o build/res_libs.zip --dir lib/res/res");
+	system("$TOOLS_DIR/aapt2 compile -o \"build/res_libs.zip\" --dir \"lib/res/res\"");
 	exit if ($? != 0);
 
 	$aapt2_res = "build/res_libs.zip " . $aapt2_res;
@@ -374,13 +374,13 @@ if (-d "lib") {
 
 print("Compiling project resources...\n");
 
-system("$TOOLS_DIR/aapt2 compile -o build/res.zip --dir res");
+system("$TOOLS_DIR/aapt2 compile -o \"build/res.zip\" --dir \"res\"");
 exit if ($? != 0);
 
 print("Linking resources...\n");
 
 # This is what gives us the actual set of properly unique IDs
-system("$TOOLS_DIR/aapt2 link -o build/unaligned.apk --manifest AndroidManifest.xml -I $PLATFORM_DIR/android.jar --emit-ids ids.txt $aapt2_res");
+system("$TOOLS_DIR/aapt2 link -o \"build/unaligned.apk\" --manifest \"AndroidManifest.xml\" -I \"$PLATFORM_DIR/android.jar\" --emit-ids ids.txt $aapt2_res");
 exit if ($? != 0);
 
 # Load those unique IDs
@@ -413,24 +413,24 @@ if (-d $LIB_RES_DIR && -d $LIB_CLASS_DIR) {
 	print("Compiling resource maps...\n");
 	mkdir("$LIB_RES_DIR/R") if (!-d "$LIB_RES_DIR/R");
 
-	system("$CMD_JAVAC -source 8 -target 8 -bootclasspath $PLATFORM_DIR/android.jar -d $LIB_RES_DIR/R \@rjava_list.txt");
+	system("$CMD_JAVAC -source 8 -target 8 -bootclasspath $PLATFORM_DIR/android.jar -d \"$LIB_RES_DIR/R\" \@rjava_list.txt");
 	exit if ($? != 0);
 	unlink("rjava_list.txt");
 
-	system("$CMD_JAR --create --file build/libs_r.jar -C '$LIB_RES_DIR/R' .");
+	system("$CMD_JAR --create --file \"build/libs_r.jar\" -C \"$LIB_RES_DIR/R\" .");
 	exit if ($? != 0);
 
 	print("Compiling resource maps into DEX bytecode...\n");
-	system("$CMD_D8 --intermediate build/libs_r.jar --classpath $PLATFORM_DIR/android.jar --output build");
+	system("$CMD_D8 --intermediate \"build/libs_r.jar\" --classpath \"$PLATFORM_DIR/android.jar\" --output \"build\"");
 	exit if ($? != 0);
 	rename("build/classes.dex", "build/libs_r.dex");
 
 	print("Fusing library classes into a .JAR...\n");
-	system("$CMD_JAR --create --file build/libs.jar -C '$LIB_CLASS_DIR' .");
+	system("$CMD_JAR --create --file \"build/libs.jar\" -C \"$LIB_CLASS_DIR\" .");
 	exit if ($? != 0);
 
 	print("Compiling library .JAR into DEX bytecode...\n");
-	system("$CMD_D8 --intermediate build/libs.jar --classpath $PLATFORM_DIR/android.jar --output build");
+	system("$CMD_D8 --intermediate \"build/libs.jar\" --classpath \"$PLATFORM_DIR/android.jar\" --output \"build\"");
 	exit if ($? != 0);
 	rename("build/classes.dex", "build/libs.dex");
 }

--- a/link.pl
+++ b/link.pl
@@ -9,7 +9,6 @@ my $SDK_DIR;
 my $TOOLS_DIR;
 my $PLATFORM_DIR;
 
-my $CMD_DELETE;
 my $CMD_JAR;
 my $CMD_JAVAC;
 my $CMD_JAVA;
@@ -388,7 +387,6 @@ open(my $fh, '<', "ids.txt");
 chomp(my @ids = <$fh>);
 close($fh);
 
-# system("$CMD_DELETE \"ids.txt\"");
 unlink("ids.txt");
 
 print("Generating project R.txt...\n");

--- a/make.sh
+++ b/make.sh
@@ -48,7 +48,7 @@ if [ ${#java_list} -gt 2 ]; then
 	[ -f "build/R.jar" ] && jars+="build/R.jar${SEP}"
 	[ -f "build/libs.jar" ] && jars+="build/libs.jar${SEP}"
 
-	$CMD_JAVAC -source 8 -target 8 -bootclasspath $jars -d build $java_list || exit
+	$CMD_JAVAC --release 8 -classpath $jars -d build $java_list || exit
 	found_src=1
 fi
 if [ ${#kt_list} -gt 2 ]; then

--- a/make.sh
+++ b/make.sh
@@ -37,7 +37,7 @@ fi
 echo Compiling project source...
 
 java_list=`$CMD_FIND_SRC_JAVA`
-kt_list=`$CMD_FIND_SRC_KOTLIN` || ""
+# kt_list=`$CMD_FIND_SRC_KOTLIN` || ""
 
 # If string length of java_list > 2 then we've got some Java source
 # I picked '2' in case newlines bump it up from 0, though it's likely overkill
@@ -51,10 +51,10 @@ if [ ${#java_list} -gt 2 ]; then
 	$CMD_JAVAC -source 8 -target 8 -bootclasspath $jars -d build $java_list || exit
 	found_src=1
 fi
-if [ ${#kt_list} -gt 2 ]; then
-	$CMD_KOTLINC -d build -cp "build/R.jar${SEP}build/libs.jar${SEP}$PLATFORM_DIR/android.jar" -jvm-target 1.8 $kt_list || exit
-	found_src=1
-fi
+# if [ ${#kt_list} -gt 2 ]; then
+# 	$CMD_KOTLINC -d build -cp "$PLATFORM_DIR/android.jar${SEP}build/R.jar${SEP}build/libs.jar" -jvm-target 1.8 $kt_list || exit
+# 	found_src=1
+# fi
 
 #if (( ! $found_src )); then
 #	echo No project sources were found in the 'src' folder.

--- a/make.sh
+++ b/make.sh
@@ -69,7 +69,7 @@ dex_list=""
 [ -f "build/kotlin.dex" ] && dex_list+=" build/kotlin.dex"
 class_list=""
 [ -d "build/$package_path" ] && class_list="build/$package_path/*"
-$CMD_D8 --classpath $PLATFORM_DIR/android.jar $dex_list $class_list --output build || exit
+$CMD_D8 --classpath "$PLATFORM_DIR/android.jar" $dex_list $class_list --output build || exit
 
 echo Creating APK...
 
@@ -80,13 +80,13 @@ $TOOLS_DIR/aapt2 link -o build/unaligned.apk --manifest AndroidManifest.xml -I $
 
 # Pack the DEX file into a new APK file
 cd build
-$CMD_7Z a -tzip unaligned.apk classes.dex > /dev/null
+$CMD_7Z a -tzip unaligned.apk classes.dex > $DEV_NULL
 cd ..
 
 for t in ${TARGET_ARCHES[@]}; do
 	if [ -d $t ]; then
-		$CMD_7Z a -tzip build/unaligned.apk $t > /dev/null
-		$CMD_7Z rn -tzip build/unaligned.apk $t lib/$t > /dev/null
+		$CMD_7Z a -tzip build/unaligned.apk $t > $DEV_NULL
+		$CMD_7Z rn -tzip build/unaligned.apk $t lib/$t > $DEV_NULL
 	fi
 done
 

--- a/make.sh
+++ b/make.sh
@@ -19,7 +19,7 @@ fi
 echo Cleaning build...
 
 # Deletes all folders and APK files inside the build folder
-$CMD_DELETE build/*.apk build/*/ 2> /dev/null
+rm -rf build/*.apk build/*/ 2> $DEV_NULL
 
 MF=`cat AndroidManifest.xml`
 TERM="package=[\'\"]([a-z0-9.]+)"
@@ -36,19 +36,19 @@ fi
 
 echo Compiling project source...
 
-java_list=`$CMD_FIND src -name "*.java"`
-kt_list=`$CMD_FIND src -name "*.kt"`
+java_list=`$CMD_FIND_SRC_JAVA`
+kt_list=`$CMD_FIND_SRC_KOTLIN` || ""
 
 # If string length of java_list > 2 then we've got some Java source
 # I picked '2' in case newlines bump it up from 0, though it's likely overkill
 found_src=0
 if [ ${#java_list} -gt 2 ]; then
 	jars=""
+	jars+="$PLATFORM_DIR/android.jar${SEP}"
 	[ -f "build/R.jar" ] && jars+="build/R.jar${SEP}"
 	[ -f "build/libs.jar" ] && jars+="build/libs.jar${SEP}"
-	jars+="$PLATFORM_DIR/android.jar"
 
-	$CMD_JAVAC -source 11 -target 11 -classpath $jars -d build $java_list || exit
+	$CMD_JAVAC -source 8 -target 8 -bootclasspath $jars -d build $java_list || exit
 	found_src=1
 fi
 if [ ${#kt_list} -gt 2 ]; then

--- a/make.sh
+++ b/make.sh
@@ -13,13 +13,13 @@ OS=`uname -s`
 [[ $OS =~ "CYGWIN" || $OS =~ "MINGW" || $OS =~ "MSYS" ]] && SEP=";"
 
 if [ ! -d "build" ]; then
-	mkdir build
+	$CMD_MKDIR build
 fi
 
 echo Cleaning build...
 
 # Deletes all folders and APK files inside the build folder
-rm -rf build/*.apk build/*/ 2> $DEV_NULL
+$CMD_DELETE build/*.apk build/*/ 2> $DEV_NULL
 
 MF=`cat AndroidManifest.xml`
 TERM="package=[\'\"]([a-z0-9.]+)"
@@ -36,8 +36,8 @@ fi
 
 echo Compiling project source...
 
-java_list=`$CMD_FIND_SRC_JAVA`
-# kt_list=`$CMD_FIND_SRC_KOTLIN` || ""
+java_list=`$CMD_FIND src -name "*.java"`
+kt_list=`$CMD_FIND src -name "*.kt"`
 
 # If string length of java_list > 2 then we've got some Java source
 # I picked '2' in case newlines bump it up from 0, though it's likely overkill
@@ -51,10 +51,10 @@ if [ ${#java_list} -gt 2 ]; then
 	$CMD_JAVAC -source 8 -target 8 -bootclasspath $jars -d build $java_list || exit
 	found_src=1
 fi
-# if [ ${#kt_list} -gt 2 ]; then
-# 	$CMD_KOTLINC -d build -cp "$PLATFORM_DIR/android.jar${SEP}build/R.jar${SEP}build/libs.jar" -jvm-target 1.8 $kt_list || exit
-# 	found_src=1
-# fi
+if [ ${#kt_list} -gt 2 ]; then
+	$CMD_KOTLINC -d build -cp "$PLATFORM_DIR/android.jar${SEP}build/R.jar${SEP}build/libs.jar" -jvm-target 1.8 $kt_list || exit
+	found_src=1
+fi
 
 #if (( ! $found_src )); then
 #	echo No project sources were found in the 'src' folder.


### PR DESCRIPTION
I was having difficulties getting the scripts to run in windows git-bash, and a lot of it had to to with path strings.
This PR improves the compatibility of the scripts with windows, and can also compile projects with dependencies (such as androidx).

Overview of the changes made:
- set `API_LEVEL` to 28, as the final `make.sh` script fails during compilation at higher api level. possibly related to #4 .
- modify the bash variables in `include.sh`, so that they reflect windows paths and commands, rather than linux's .
- escape all paths in all scripts with double quotation marks (`\" ... \"`), instead of single quotation (`' ... '`). this is because paths begining with a single quotation and ending with one are perfectly valid in windows, thus making the intended paths incorrect.
- in `export-libs.pl`, make sure that files are opened in binary mode rather than text.
  without `binmode($fh);`, the resource pngs of androidx were getting corrupted due to their eighth magic byte (`0x0A` or "\n") being re-encoded as CRLF (`0x0D0A` or "\r\n").
- in `make.sh`:
  - place the path to `android.jar` at the top, otherwise java fails to import the android classes in our `MainActivity.java`, because they were not defined prior.
  - reduce javac compilation source and target from `11` to `8`, otherwise a compilation error is thrown.
    this could be due to the fact we previously compiled the linked libraries using target `8`, in `link.pl`.
  - ignore kotlin compilation altogether, as I couldn't find a suitable shell command in windows that will not throw an error if not kotlin source files are found by the find command (`$CMD_FIND_SRC_KOTLIN`).
- add `.gitignore` to ignore leftovers from building.

Fixes to consider before merging:
- The shell variables in this PR certainly need to be modified back their neutral linux commands state. However, I don't know which ones should be reverted back. I'll probably be reasonable to keep os-specific commands mentioned in the comments, so as to not confuse the end user too much.
- Kotlin compilation will need to be re-enabled, without causing issues in windows when no kotlin source files are found.
- Should `.gitignore` be removed?
